### PR TITLE
Update for new problematic attributes

### DIFF
--- a/module.prop
+++ b/module.prop
@@ -3,4 +3,4 @@ name=BetterKnownInstalled (BKI)
 version=v1.3.3
 versionCode=1337
 author=@T3SL4
-description=Patching (installer, installerUid, installInitiator, installOriginator) in packages.xml and cleaning packaga-warnings.xml for defeating DroidGuard: UNKNOWN_INSTALLED
+description=Patching (installer, installerUid, installInitiator, installOriginator) in packages.xml and cleaning packages-warnings.xml for defeating DroidGuard: UNKNOWN_INSTALLED

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -152,6 +152,15 @@ process_xml() {
 
     # 4. Remove installOriginator attribute.
     sed -i -E 's/[\r\n ]*installOriginator="[^"]*"//g' "$xml_temp"
+    
+    # 5. Remove isOrphaned attribute if value is true.
+    sed -i 's/isOrphaned="true"//g' "$xml_temp"
+
+    # 6. Remove installInitiatorUninstalled attribute if value is true.
+    sed -i 's/installInitiatorUninstalled="true"//g' "$xml_temp"
+
+    # 7. Change packageSource attribute to PACKAGE_SOURCE_STORE (constant value 2).
+    sed -i 's/packageSource="[^2]"/packageSource="2"/g' "$xml_temp"
   fi
 
   # Rotate backups


### PR DESCRIPTION
Remove isOrphaned attribute if value is true.
Remove installInitiatorUninstalled attribute if value is true.
Change packageSource attribute to PACKAGE_SOURCE_STORE (constant value 2).

Note: testing shows only installInitiatorUninstalled="true" currently results in UNKNOWN_INSTALLED but others look suspicious so could be added.